### PR TITLE
NoTask - Added config.yml to allow env switching for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,11 @@ Feature: Contact us
 3 steps (3 passed)
 0m6.396s
 ```
+
+***Running tests on different environments***
+
+There is a config.yml file (config/config.yml) in the project.  Inside this file, the different URL's are listed for the supported environments.  In order to specify which environment to run the tests on you can add a command line switch
+`TEST_ENV=production` to the end of the run command.  EG.
+`bundle exec cucumber features TEST_ENV=production`
+
+By default the tests run on the `test` url unless you add the command line switch

--- a/features/config/config.yml
+++ b/features/config/config.yml
@@ -1,0 +1,5 @@
+test:
+  :url: https://jellyfish-test.jellyfish.co.uk
+
+production:
+  :url: http://www.jellyfish.co.uk

--- a/features/home_page.feature
+++ b/features/home_page.feature
@@ -4,7 +4,7 @@ Feature: Home Page tests
   verify the home page footer contact us form can be completed (not submitted)
 
 Background:
-  Given I vist "https://jellyfish-test.jellyfish.co.uk/"
+  Given I vist the home page
 
 Scenario: Verify home page has loaded
   Then I can see the footer has loaded

--- a/features/step_definitions/home_page.rb
+++ b/features/step_definitions/home_page.rb
@@ -1,5 +1,5 @@
-Given(/^I vist "([^"]*)"$/) do |url|
-  @home.openSite(url)
+Given(/^I vist the home page$/) do
+  @home.openSite($BASE_URL)
   @page.cookieMessagePresent
 end
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -2,6 +2,12 @@ require 'rubygems'
 require 'cucumber'
 require 'pry'
 require 'selenium-webdriver'
+require "yaml"
+
+
+ENV['TEST_ENV'] ||= 'test'
+project_root = File.expand_path('../..', __FILE__)
+$BASE_URL = YAML.load_file(project_root + "/config/config.yml")[ENV['TEST_ENV']][:url]
 
 Before do |scenario|
   @driver = Selenium::WebDriver.for :firefox


### PR DESCRIPTION
***Changes***
* Parameterised the environments to allow tests to be run against Test or Live (more envs can be added via config.yml
* Updated README.md file to document how to use the switch on the command line (NB TEST is the default run env if no explicit env is set at runtime