### PR TITLE
Sidebar contact for added

### DIFF
--- a/features/home_page.feature
+++ b/features/home_page.feature
@@ -1,7 +1,8 @@
 @homepage
 Feature: Home Page tests
   verfiy the footer has loaded correctly (basic test for framework)
-  verify the home page footer contact us form can be completed (not submitted)
+  verify the home page footer contact us form can be completed (not submitted due to recaptcha)
+  navigate to the contact us form via sidebar and verify correct page loaded
 
 Background:
   Given I vist the home page
@@ -18,3 +19,7 @@ Scenario: site visitors can complete the home page footer contact us form
   | company_name  | Company Name                            |
   | message       | This is a test contact us form message  |
   Then I can verify the form is complete
+
+  Scenario: verify that site visitors can navigate to the contact us from via the site sidebar
+    When I navigate to the contact form using the sidebar link
+    Then I am on the "Contact Us" page

--- a/features/home_page.feature
+++ b/features/home_page.feature
@@ -1,8 +1,7 @@
 @homepage
 Feature: Home Page tests
-  verify the footer has loaded correctly (basic test for framework)
-  complete the home page footer contact us form (not submitted due to recaptcha)
-  navigate to and complete the home page footer contact us form (not submitted due to recaptcha)
+  verfiy the footer has loaded correctly (basic test for framework)
+  verify the home page footer contact us form can be completed (not submitted)
 
 Background:
   Given I vist the home page
@@ -13,13 +12,9 @@ Scenario: Verify home page has loaded
 
 Scenario: site visitors can complete the home page footer contact us form
   When I complete the contact form with:
-    | contactname   | Contact Page User                       |
-    | email         | email@email.com                         |
-    | phone         | 01273123456                             |
-    | company_name  | Company Name                            |
-    | message       | This is a test contact us form message  |
+  | contactname   | Contact Page User                       |
+  | email         | email@email.com                         |
+  | phone         | 01273123456                             |
+  | company_name  | Company Name                            |
+  | message       | This is a test contact us form message  |
   Then I can verify the form is complete
-
-Scenario: verify that site visitors can navigate to the contact us from via the site sidebar
-  When I navigate to the contact form using the sidebar link
-  Then I am on the "Contact Us" page

--- a/features/home_page.feature
+++ b/features/home_page.feature
@@ -1,7 +1,8 @@
 @homepage
 Feature: Home Page tests
-  verfiy the footer has loaded correctly (basic test for framework)
-  verify the home page footer contact us form can be completed (not submitted)
+  verify the footer has loaded correctly (basic test for framework)
+  complete the home page footer contact us form (not submitted due to recaptcha)
+  navigate to and complete the home page footer contact us form (not submitted due to recaptcha)
 
 Background:
   Given I vist the home page
@@ -12,9 +13,13 @@ Scenario: Verify home page has loaded
 
 Scenario: site visitors can complete the home page footer contact us form
   When I complete the contact form with:
-  | contactname   | Contact Page User                       |
-  | email         | email@email.com                         |
-  | phone         | 01273123456                             |
-  | company_name  | Company Name                            |
-  | message       | This is a test contact us form message  |
+    | contactname   | Contact Page User                       |
+    | email         | email@email.com                         |
+    | phone         | 01273123456                             |
+    | company_name  | Company Name                            |
+    | message       | This is a test contact us form message  |
   Then I can verify the form is complete
+
+Scenario: verify that site visitors can navigate to the contact us from via the site sidebar
+  When I navigate to the contact form using the sidebar link
+  Then I am on the "Contact Us" page

--- a/features/step_definitions/home_page.rb
+++ b/features/step_definitions/home_page.rb
@@ -24,15 +24,6 @@ When(/^I complete the contact form with:$/) do |table|
   @ContactForm.completeContactForm(@table)
 end
 
-When(/^I navigate to the contact form using the sidebar link$/) do
-  @ContactForm.sidebarContactForm
-end
-
 Then(/^I can verify the form is complete$/) do
   @ContactForm.verify_submit_button
-end
-
-
-Then(/^I am on the "([^"]*)" page$/) do |page_title|
-  @page.verifyOnExpectedPage(page_title)
 end

--- a/features/step_definitions/home_page.rb
+++ b/features/step_definitions/home_page.rb
@@ -24,6 +24,14 @@ When(/^I complete the contact form with:$/) do |table|
   @ContactForm.completeContactForm(@table)
 end
 
+When(/^I navigate to the contact form using the sidebar link$/) do
+  @ContactForm.sidebarContactForm
+end
+
 Then(/^I can verify the form is complete$/) do
   @ContactForm.verify_submit_button
+end
+
+Then(/^I am on the "([^"]*)" page$/) do |page_title|
+  @page.verifyOnExpectedPage(page_title)
 end

--- a/features/step_definitions/home_page.rb
+++ b/features/step_definitions/home_page.rb
@@ -24,6 +24,15 @@ When(/^I complete the contact form with:$/) do |table|
   @ContactForm.completeContactForm(@table)
 end
 
+When(/^I navigate to the contact form using the sidebar link$/) do
+  @ContactForm.sidebarContactForm
+end
+
 Then(/^I can verify the form is complete$/) do
   @ContactForm.verify_submit_button
+end
+
+
+Then(/^I am on the "([^"]*)" page$/) do |page_title|
+  @page.verifyOnExpectedPage(page_title)
 end

--- a/features/support/pages/base_page.rb
+++ b/features/support/pages/base_page.rb
@@ -1,53 +1,59 @@
 class Page
 
-def initialize(driver)
-  @driver = driver
-end
-
-def verify_page
-  wait = Selenium::WebDriver::Wait.new(:timeout => 10)
-  wait.until { @driver.find_element(:id => 'main') }
-end
-
-def clickElementBy (type, value)
-    findElementBy(type, value).click
-end
-
-def findElementBy (type, value)
-  if type=="class"
-      element=@driver.find_element :class => value
-  elsif type=="css"
-      element=@driver.find_element :css => value
-  elsif type=="id"
-      element=@driver.find_element :id => value
-  elsif type=="link"
-      element=@driver.find_element :link => value
-  elsif type=="name"
-      element=@driver.find_element :name => value
-  elsif type=="partial_link"
-      element=@driver.find_element :partial_link_text => value
-  elsif type=="tag"
-      element=@driver.find_element :tag_name => value
-  elsif type=="xpath"
-      element=@driver.find_element :xpath => value
-  else
-      p "incorrect selector type"
+  def initialize(driver)
+    @driver = driver
   end
-end
 
-def cookieMessagePresent
-  sleep 2 #allow the cookie message to load if it's going to - it's slow to load
-  cookie_page = findElementBy("css", ".cookies-box")
-
-  if cookie_page.displayed?
-    then closeCookieMessage
-  else
-    puts "cookie box not present"
+  def verify_page
+    wait = Selenium::WebDriver::Wait.new(:timeout => 10)
+    wait.until { @driver.find_element(:id => 'main') }
   end
-end
 
-def closeCookieMessage
-  findElementBy("css", "body > div.cookies-overlay > div > button").click
-end
+  def clickElementBy (type, value)
+      findElementBy(type, value).click
+  end
 
+  def findElementBy (type, value)
+    if type=="class"
+        element=@driver.find_element :class => value
+    elsif type=="css"
+        element=@driver.find_element :css => value
+    elsif type=="id"
+        element=@driver.find_element :id => value
+    elsif type=="link"
+        element=@driver.find_element :link => value
+    elsif type=="name"
+        element=@driver.find_element :name => value
+    elsif type=="partial_link"
+        element=@driver.find_element :partial_link_text => value
+    elsif type=="tag"
+        element=@driver.find_element :tag_name => value
+    elsif type=="xpath"
+        element=@driver.find_element :xpath => value
+    else
+        p "incorrect selector type"
+    end
+  end
+
+  def cookieMessagePresent
+    sleep 2 #allow the cookie message to load if it's going to - it's slow to load
+    cookie_page = findElementBy("css", ".cookies-box")
+
+    if cookie_page.displayed?
+      then closeCookieMessage
+    else
+      puts "cookie box not present"
+    end
+  end
+
+  def closeCookieMessage
+    findElementBy("css", "body > div.cookies-overlay > div > button").click
+  end
+
+  def verifyOnExpectedPage(page_title)
+    expectedpage = "holdingvalue"
+    expectedpage.replace page_title
+    actualpage = findElementBy("css", ".content-hero-title > h1:nth-child(1)").text
+    actualpage == expectedpage
+  end
 end

--- a/features/support/pages/base_page.rb
+++ b/features/support/pages/base_page.rb
@@ -1,53 +1,61 @@
 class Page
 
-def initialize(driver)
-  @driver = driver
-end
-
-def verify_page
-  wait = Selenium::WebDriver::Wait.new(:timeout => 10)
-  wait.until { @driver.find_element(:id => 'main') }
-end
-
-def clickElementBy (type, value)
-    findElementBy(type, value).click
-end
-
-def findElementBy (type, value)
-  if type=="class"
-      element=@driver.find_element :class => value
-  elsif type=="css"
-      element=@driver.find_element :css => value
-  elsif type=="id"
-      element=@driver.find_element :id => value
-  elsif type=="link"
-      element=@driver.find_element :link => value
-  elsif type=="name"
-      element=@driver.find_element :name => value
-  elsif type=="partial_link"
-      element=@driver.find_element :partial_link_text => value
-  elsif type=="tag"
-      element=@driver.find_element :tag_name => value
-  elsif type=="xpath"
-      element=@driver.find_element :xpath => value
-  else
-      p "incorrect selector type"
+  def initialize(driver)
+    @driver = driver
   end
-end
 
-def cookieMessagePresent
-  sleep 2 #allow the cookie message to load if it's going to - it's slow to load
-  cookie_page = findElementBy("css", ".cookies-box")
-
-  if cookie_page.displayed?
-    then closeCookieMessage
-  else
-    puts "cookie box not present"
+  def verify_page
+    wait = Selenium::WebDriver::Wait.new(:timeout => 10)
+    wait.until { @driver.find_element(:id => 'main') }
   end
-end
 
-def closeCookieMessage
-  findElementBy("css", "body > div.cookies-overlay > div > button").click
-end
+  def clickElementBy (type, value)
+      findElementBy(type, value).click
+  end
+
+  def findElementBy (type, value)
+    if type=="class"
+        element=@driver.find_element :class => value
+    elsif type=="css"
+        element=@driver.find_element :css => value
+    elsif type=="id"
+        element=@driver.find_element :id => value
+    elsif type=="link"
+        element=@driver.find_element :link => value
+    elsif type=="name"
+        element=@driver.find_element :name => value
+    elsif type=="partial_link"
+        element=@driver.find_element :partial_link_text => value
+    elsif type=="tag"
+        element=@driver.find_element :tag_name => value
+    elsif type=="xpath"
+        element=@driver.find_element :xpath => value
+    else
+        p "incorrect selector type"
+    end
+  end
+
+  def cookieMessagePresent
+    sleep 2 #allow the cookie message to load if it's going to - it's slow to load
+    cookie_page = findElementBy("css", ".cookies-box")
+
+    if cookie_page.displayed?
+      then closeCookieMessage
+    else
+      puts "cookie box not present"
+    end
+  end
+
+  def closeCookieMessage
+    findElementBy("css", "body > div.cookies-overlay > div > button").click
+  end
+
+  # Generic method to verify H1 tag against the stated Page in the feature
+  def verifyOnExpectedPage(page_title)
+    expectedpage = "holdingvalue"
+    expectedpage.replace page_title
+    actualpage = findElementBy("css", ".content-hero-title > h1:nth-child(1)").text
+    actualpage == expectedpage
+  end
 
 end

--- a/features/support/pages/base_page.rb
+++ b/features/support/pages/base_page.rb
@@ -1,61 +1,53 @@
 class Page
 
-  def initialize(driver)
-    @driver = driver
-  end
+def initialize(driver)
+  @driver = driver
+end
 
-  def verify_page
-    wait = Selenium::WebDriver::Wait.new(:timeout => 10)
-    wait.until { @driver.find_element(:id => 'main') }
-  end
+def verify_page
+  wait = Selenium::WebDriver::Wait.new(:timeout => 10)
+  wait.until { @driver.find_element(:id => 'main') }
+end
 
-  def clickElementBy (type, value)
-      findElementBy(type, value).click
-  end
+def clickElementBy (type, value)
+    findElementBy(type, value).click
+end
 
-  def findElementBy (type, value)
-    if type=="class"
-        element=@driver.find_element :class => value
-    elsif type=="css"
-        element=@driver.find_element :css => value
-    elsif type=="id"
-        element=@driver.find_element :id => value
-    elsif type=="link"
-        element=@driver.find_element :link => value
-    elsif type=="name"
-        element=@driver.find_element :name => value
-    elsif type=="partial_link"
-        element=@driver.find_element :partial_link_text => value
-    elsif type=="tag"
-        element=@driver.find_element :tag_name => value
-    elsif type=="xpath"
-        element=@driver.find_element :xpath => value
-    else
-        p "incorrect selector type"
-    end
+def findElementBy (type, value)
+  if type=="class"
+      element=@driver.find_element :class => value
+  elsif type=="css"
+      element=@driver.find_element :css => value
+  elsif type=="id"
+      element=@driver.find_element :id => value
+  elsif type=="link"
+      element=@driver.find_element :link => value
+  elsif type=="name"
+      element=@driver.find_element :name => value
+  elsif type=="partial_link"
+      element=@driver.find_element :partial_link_text => value
+  elsif type=="tag"
+      element=@driver.find_element :tag_name => value
+  elsif type=="xpath"
+      element=@driver.find_element :xpath => value
+  else
+      p "incorrect selector type"
   end
+end
 
-  def cookieMessagePresent
-    sleep 2 #allow the cookie message to load if it's going to - it's slow to load
-    cookie_page = findElementBy("css", ".cookies-box")
+def cookieMessagePresent
+  sleep 2 #allow the cookie message to load if it's going to - it's slow to load
+  cookie_page = findElementBy("css", ".cookies-box")
 
-    if cookie_page.displayed?
-      then closeCookieMessage
-    else
-      puts "cookie box not present"
-    end
+  if cookie_page.displayed?
+    then closeCookieMessage
+  else
+    puts "cookie box not present"
   end
+end
 
-  def closeCookieMessage
-    findElementBy("css", "body > div.cookies-overlay > div > button").click
-  end
-
-  # Generic method to verify H1 tag against the stated Page in the feature
-  def verifyOnExpectedPage(page_title)
-    expectedpage = "holdingvalue"
-    expectedpage.replace page_title
-    actualpage = findElementBy("css", ".content-hero-title > h1:nth-child(1)").text
-    actualpage == expectedpage
-  end
+def closeCookieMessage
+  findElementBy("css", "body > div.cookies-overlay > div > button").click
+end
 
 end

--- a/features/support/pages/contact_form.rb
+++ b/features/support/pages/contact_form.rb
@@ -14,7 +14,7 @@ class ContactForm < Page
   def enter_contact_name(table)
     contactname = findElementBy("id", "edit-submitted-column1-name")
     @driver.execute_script("arguments[0].scrollIntoView(true);", contactname)
-    binding.pry
+
     contactNameData = table["contactname"]
     contactname.send_keys(contactNameData)
   end
@@ -62,9 +62,5 @@ class ContactForm < Page
 
   def verify_submit_button
     findElementBy("css", ".webform-submit").displayed?
-  end
-
-  def sidebarContactForm
-    findElementBy("css", ".top-menu > li:nth-child(11) > a:nth-child(2)").click
   end
 end

--- a/features/support/pages/contact_form.rb
+++ b/features/support/pages/contact_form.rb
@@ -14,7 +14,7 @@ class ContactForm < Page
   def enter_contact_name(table)
     contactname = findElementBy("id", "edit-submitted-column1-name")
     @driver.execute_script("arguments[0].scrollIntoView(true);", contactname)
-
+    binding.pry
     contactNameData = table["contactname"]
     contactname.send_keys(contactNameData)
   end
@@ -62,5 +62,9 @@ class ContactForm < Page
 
   def verify_submit_button
     findElementBy("css", ".webform-submit").displayed?
+  end
+
+  def sidebarContactForm
+    findElementBy("css", ".top-menu > li:nth-child(11) > a:nth-child(2)").click
   end
 end

--- a/features/support/pages/contact_form.rb
+++ b/features/support/pages/contact_form.rb
@@ -63,4 +63,8 @@ class ContactForm < Page
   def verify_submit_button
     findElementBy("css", ".webform-submit").displayed?
   end
+
+  def sidebarContactForm
+    findElementBy("css", ".top-menu > li:nth-child(11) > a:nth-child(2)").click
+  end
 end


### PR DESCRIPTION
***Changes***
* Added a new feature to verify the contact page loads when selected from the side menu.  
* Generic function added to verify the page H1 tag against the page noted in the `when` step.  This can be reused for subsequent page checks.

***Results***
```Scenario: verify that site visitors can navigate to the contact us from via the site sidebar # features/home_page.feature:23
    When I navigate to the contact form using the sidebar link                                 # features/step_definitions/home_page.rb:27
    Then I am on the "Contact Us" page                                                         # features/step_definitions/home_page.rb:35

3 scenarios (3 passed)
9 steps (9 passed)
0m38.088s```