### PR TITLE
NoTask - updated rubocop to v0.49.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,5 @@ source 'http://rubygems.org'
 
 gem 'cucumber'
 gem 'pry', '~> 0.10.3'
-gem 'rubocop', '~> 0.39.0'
+gem 'rubocop', '~> 0.49.0'
 gem 'selenium-webdriver'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,6 +29,7 @@ GEM
     method_source (0.8.2)
     multi_json (1.13.1)
     multi_test (0.1.2)
+    parallel (1.12.1)
     parser (2.5.1.0)
       ast (~> 2.4.0)
     powerpack (0.1.1)
@@ -39,8 +40,9 @@ GEM
     rainbow (2.2.2)
       rake
     rake (12.3.1)
-    rubocop (0.39.0)
-      parser (>= 2.3.0.7, < 3.0)
+    rubocop (0.49.1)
+      parallel (~> 1.10)
+      parser (>= 2.3.3.1, < 3.0)
       powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.7)
@@ -59,7 +61,7 @@ PLATFORMS
 DEPENDENCIES
   cucumber
   pry (~> 0.10.3)
-  rubocop (~> 0.39.0)
+  rubocop (~> 0.49.0)
   selenium-webdriver
 
 BUNDLED WITH


### PR DESCRIPTION
***Changes***
Github Vunerability report on previous version `0.39.0` - updating to latest version
```
CVE-2017-8418
Low severity
RuboCop 0.48.1 and earlier does not use /tmp in safe way, allowing local users to exploit this to tamper with cache f...

Gemfile.lock update suggested:
rubocop ~> 0.49.0
Always verify the validity and compatibility of suggestions with your codebase.
```

***Tests***
ran new version against codebase
```
~/qa-projects/ruby_cucumber [development] $ rubocop
Inspecting 7 files
.......

7 files inspected, no offenses detected
```